### PR TITLE
querydsl count 쿼리 최적화

### DIFF
--- a/src/main/java/me/hjhng125/querydsl/repository/MemberRepositoryCustom.java
+++ b/src/main/java/me/hjhng125/querydsl/repository/MemberRepositoryCustom.java
@@ -11,5 +11,6 @@ public interface MemberRepositoryCustom {
     List<MemberTeamDTO> search(MemberSearchCondition condition);
     Page<MemberTeamDTO> searchPageSimple(MemberSearchCondition condition, Pageable pageable);
     Page<MemberTeamDTO> searchPageComplex(MemberSearchCondition condition, Pageable pageable);
+    Page<MemberTeamDTO> searchPageNoCountQuery(MemberSearchCondition condition, Pageable pageable);
 
 }

--- a/src/test/java/me/hjhng125/querydsl/repository/MemberRepositoryTest.java
+++ b/src/test/java/me/hjhng125/querydsl/repository/MemberRepositoryTest.java
@@ -120,4 +120,22 @@ class MemberRepositoryTest {
             .containsExactly("member1", "member2", "member3");
 
     }
+
+    @Test
+    void searchPageNoCount() {
+        //given
+        MemberSearchCondition memberSearchCondition = MemberSearchCondition.builder()
+            .build();
+        PageRequest pageRequest = PageRequest.of(0, 4);
+
+        //when
+        Page<MemberTeamDTO> memberTeamDTOPage = memberRepository.searchPageNoCountQuery(memberSearchCondition, pageRequest);
+
+        //then
+        assertThat(memberTeamDTOPage.getSize()).isEqualTo(4);
+        assertThat(memberTeamDTOPage.getContent())
+            .extracting("username")
+            .containsExactly("member1", "member2", "member3", "member4");
+
+    }
 }


### PR DESCRIPTION
PageableExecutionUtils.getPage()