### PR TITLE
querydsl web support

### DIFF
--- a/src/main/java/me/hjhng125/querydsl/InitMember.java
+++ b/src/main/java/me/hjhng125/querydsl/InitMember.java
@@ -23,7 +23,7 @@ public class InitMember {
     }
 
     /**
-     * https://docs.spring.io/spring-framework/docs/current/reference/html/data-access.html#transaction-declarative-annotations
+     * https://docs.spring.io/spring-framework/docs/current/reference/html/data-access.html#transaction-declarative-annotations<p/>
      * spring 문서에 의하면 spring default proxy mode는 외부 메서드에서 호출되었을 때만 프록시가 동작하고,
      * 해당 객체 내부에 의한 호출에는 @Transactional 어노테이션이 선언되었다해도 런타임 시에 실제 트랜잭션이 동작하지 않을 수 있다고 한.
      * 또한 프록시가 예상되는 동작을 하기 위해선 완전히 초기화가 되어야 하기에

--- a/src/main/java/me/hjhng125/querydsl/controller/MemberController.java
+++ b/src/main/java/me/hjhng125/querydsl/controller/MemberController.java
@@ -48,6 +48,10 @@ public class MemberController {
      * spring data의 Sort를 querydsl에 적용하기 <br/> OrderSpecifier 사용 <br/> spring data의 Sort는 하나의 엔터티에서 조회할 경우는 가능하나, join이 포함된 복잡한 쿼리에서 잘 동작하지 않는다. <br/> 그런 경우 파라미터로 직접 받아서 사용한다.
      */
 
+    /**
+     * 테이블의 연관관계의 경우 제대로 동작하지 않음 확인 <br/>
+     * QuerydslPredicateExecutor를 사용하여 연관관계가 있는 엔터티 조회 시 무한으로 순회하는 현상 발견
+     */
     @GetMapping("/v5/members")
     public Iterable<Member> searchMemberV5(MemberSearchCondition condition) {
         return memberRepository.findAll(

--- a/src/main/java/me/hjhng125/querydsl/controller/MemberController.java
+++ b/src/main/java/me/hjhng125/querydsl/controller/MemberController.java
@@ -1,13 +1,19 @@
 package me.hjhng125.querydsl.controller;
 
+import static me.hjhng125.querydsl.model.entity.QMember.member;
+
+import com.querydsl.core.types.Predicate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import me.hjhng125.querydsl.model.MemberSearchCondition;
 import me.hjhng125.querydsl.model.dto.MemberTeamDTO;
+import me.hjhng125.querydsl.model.entity.Member;
 import me.hjhng125.querydsl.repository.MemberJpaRepository;
 import me.hjhng125.querydsl.repository.MemberRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,11 +43,24 @@ public class MemberController {
     public Page<MemberTeamDTO> searchMemberV4(MemberSearchCondition condition, Pageable pageable) {
         return memberRepository.searchPageNoCountQuery(condition, pageable);
     }
+
     /**
-     * spring data의 Sort를 querydsl에 적용하기 <br/>
-     * OrderSpecifier 사용 <br/>
-     * spring data의 Sort는 하나의 엔터티에서 조회할 경우는 가능하나, join이 포함된 복잡한 쿼리에서
-     * 잘 동작하지 않는다. <br/>
-     * 그런 경우 파라미터로 직접 받아서 사용한다.
+     * spring data의 Sort를 querydsl에 적용하기 <br/> OrderSpecifier 사용 <br/> spring data의 Sort는 하나의 엔터티에서 조회할 경우는 가능하나, join이 포함된 복잡한 쿼리에서 잘 동작하지 않는다. <br/> 그런 경우 파라미터로 직접 받아서 사용한다.
      */
+
+    @GetMapping("/v5/members")
+    public Iterable<Member> searchMemberV5(MemberSearchCondition condition) {
+        return memberRepository.findAll(
+            member.age.goe(condition.getAgeGoe())
+                .and(member.age.loe(condition.getAgeLoe())));
+    }
+
+    @GetMapping("/v6/members")
+    public List<Member> searchMemberV6(@QuerydslPredicate(root = Member.class) Predicate predicate) {
+        System.out.println("predicate = " + predicate);
+        Iterable<Member> all = memberRepository.findAll(predicate);
+        List<Member> listAll = new ArrayList<>();
+        all.forEach(listAll::add);
+        return listAll;
+    }
 }

--- a/src/main/java/me/hjhng125/querydsl/repository/MemberJpaRepository.java
+++ b/src/main/java/me/hjhng125/querydsl/repository/MemberJpaRepository.java
@@ -15,7 +15,6 @@ import me.hjhng125.querydsl.model.MemberSearchCondition;
 import me.hjhng125.querydsl.model.dto.MemberTeamDTO;
 import me.hjhng125.querydsl.model.dto.QMemberTeamDTO;
 import me.hjhng125.querydsl.model.entity.Member;
-import me.hjhng125.querydsl.model.entity.QMember;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,4 +22,4 @@ logging:
   level:
     org.hibernate.SQL: debug
     # 아래 옵션은 parameter binding 시 보기 힘들어 외부 라이브러리 사용하였기에 주석 처리
-    org.hibernate.type: trace
+    #org.hibernate.type: trace

--- a/src/test/java/me/hjhng125/querydsl/MemberIGTest.java
+++ b/src/test/java/me/hjhng125/querydsl/MemberIGTest.java
@@ -1,0 +1,30 @@
+package me.hjhng125.querydsl;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import me.hjhng125.querydsl.controller.MemberController;
+import me.hjhng125.querydsl.repository.MemberJpaRepository;
+import me.hjhng125.querydsl.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+public class MemberIGTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    public void memberList() throws Exception {
+        mockMvc.perform(get("/v5/members")
+        .queryParam("age", "10"))
+            .andDo(print());
+    }
+}

--- a/src/test/java/me/hjhng125/querydsl/controller/MemberControllerTest.java
+++ b/src/test/java/me/hjhng125/querydsl/controller/MemberControllerTest.java
@@ -1,0 +1,32 @@
+package me.hjhng125.querydsl.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import me.hjhng125.querydsl.repository.MemberJpaRepository;
+import me.hjhng125.querydsl.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    MemberJpaRepository memberJpaRepository;
+    @MockBean
+    MemberRepository memberRepository;
+
+    @Test
+    void searchMemberV5() throws Exception {
+        mockMvc.perform(get("/v5/members")
+            .queryParam("age", "10"))
+            .andDo(print());
+
+    }
+}


### PR DESCRIPTION
테이블의 연관관계의 경우 제대로 동작하지 않음 확인
QuerydslPredicateExecutor를 사용하여 연관관계가 있는 엔터티 조회 시
무한으로 순회하는 현상 발견